### PR TITLE
Added code to take screenshot before and after performing actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.project
 /test-output/
 /build.bat
+.idea/
+test-drop-in-framework.iml

--- a/pom.xml
+++ b/pom.xml
@@ -210,5 +210,10 @@ Offers support of JavaScript commands to find elements in a way similar to @Find
 			<artifactId>jackson-databind</artifactId>
 			<version>2.10.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>1.3.2</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/com/salesforce/selenium/support/event/EventFiringWebDriver.java
+++ b/src/main/java/com/salesforce/selenium/support/event/EventFiringWebDriver.java
@@ -211,7 +211,7 @@ public class EventFiringWebDriver
 	}
 
 	public void takeScreenshot() {
-		if(Boolean.parseBoolean(System.getProperty("takeScreenshotBeforeAndAfterActions", "false"))) {
+		if(Boolean.parseBoolean(System.getProperty("takeScreenshotBeforeActions", "false"))) {
 			try {
 				String saveDirectoryPath = System.getProperty("screenshotSaveLocation", "");
 				String fileNamePrefix = System.getProperty("screenshotNamePrefix", "");
@@ -422,6 +422,9 @@ public class EventFiringWebDriver
 			dispatcher.beforeExecuteScript(stepBefore, script, args);
 			currentStep = stepBefore;
 
+			if(script.contains("click"))
+				takeScreenshot();
+
 			Object[] usedArgs = unpackWrappedArgs(args);
 			Object result = ((JavascriptExecutor) driver).executeScript(script, usedArgs);
 
@@ -442,6 +445,9 @@ public class EventFiringWebDriver
 			// TODO handle args
 			dispatcher.beforeExecuteAsyncScript(stepBefore, script, args);
 			currentStep = stepBefore;
+
+			if(script.contains("click"))
+				takeScreenshot();
 
 			Object[] usedArgs = unpackWrappedArgs(args);
 			Object result = ((JavascriptExecutor) driver).executeAsyncScript(script, usedArgs);
@@ -627,7 +633,6 @@ public class EventFiringWebDriver
 
 			element.click();
 
-			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.clickByElement);
 			stepAfter.setParam1(Step.getLocatorFromWebElement(element));
 			stepAfter.setElementLocator(Step.getLocatorFromWebElement(element));
@@ -895,7 +900,6 @@ public class EventFiringWebDriver
 
 			element.sendKeys(keysToSend);
 
-			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.sendKeysByElement);
 			stepAfter.setParam1(param1);
 			stepAfter.setParam2(param2);
@@ -927,7 +931,6 @@ public class EventFiringWebDriver
 
 			element.submit();
 
-			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.submit);
 			stepAfter.setParam1(Step.getLocatorFromWebElement(element));
 			dispatcher.afterSubmit(stepAfter, element);
@@ -997,7 +1000,6 @@ public class EventFiringWebDriver
 
 			navigation.back();
 
-			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.back);
 			dispatcher.afterBack(stepAfter);
 		}
@@ -1011,7 +1013,6 @@ public class EventFiringWebDriver
 
 			navigation.forward();
 
-			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.forward);
 			dispatcher.afterForward(stepAfter);
 		}
@@ -1025,7 +1026,6 @@ public class EventFiringWebDriver
 
 			navigation.refresh();
 
-			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.refresh);
 			dispatcher.afterRefresh(stepAfter);
 		}
@@ -1416,7 +1416,6 @@ public class EventFiringWebDriver
 
 			keyboard.sendKeys(keysToSend);
 
-			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.sendKeysByKeyboard);
 			stepAfter.setParam1(keysToSendString);
 			dispatcher.afterSendKeysByKeyboard(stepBefore, keysToSend);

--- a/src/main/java/com/salesforce/selenium/support/event/EventFiringWebDriver.java
+++ b/src/main/java/com/salesforce/selenium/support/event/EventFiringWebDriver.java
@@ -16,6 +16,7 @@
 //under the License.
 package com.salesforce.selenium.support.event;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.URL;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,6 +37,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.io.FileUtils;
 import org.openqa.selenium.Alert;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
@@ -207,6 +210,23 @@ public class EventFiringWebDriver
 		}
 	}
 
+	public void takeScreenshot() {
+		if(Boolean.parseBoolean(System.getProperty("takeScreenshotBeforeAndAfterActions", "false"))) {
+			try {
+				String saveDirectoryPath = System.getProperty("screenshotSaveLocation", "");
+				String fileNamePrefix = System.getProperty("screenshotNamePrefix", "");
+				String fileNamePostfix = System.getProperty("screenshotNamePostfix", "");
+				if(saveDirectoryPath.isEmpty()) {
+					saveDirectoryPath = System.getProperty("user.dir") + File.separator + "screenshotHub";
+				}
+				FileUtils.copyFile(((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE), new File(saveDirectoryPath
+						+ File.separator + fileNamePrefix + new Timestamp(System.currentTimeMillis()) + fileNamePostfix + ".png"));
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
 	/*--------------------------------------------------------------------
 	 * Section for all commands called directly from WebDriver object.
 	 *--------------------------------------------------------------------*/
@@ -216,6 +236,7 @@ public class EventFiringWebDriver
 		Step stepBefore = new Step(Type.BeforeAction, stepNumber, Cmd.close);
 		dispatcher.beforeClose(stepBefore);
 		currentStep = stepBefore;
+		takeScreenshot();
 
 		driver.close();
 		Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.close);
@@ -602,9 +623,11 @@ public class EventFiringWebDriver
 			currentStep = stepBefore;
 
 			dispatcher.beforeClick(stepBefore, element);
+			takeScreenshot();
 
 			element.click();
 
+			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.clickByElement);
 			stepAfter.setParam1(Step.getLocatorFromWebElement(element));
 			stepAfter.setElementLocator(Step.getLocatorFromWebElement(element));
@@ -868,9 +891,11 @@ public class EventFiringWebDriver
 			stepBefore.setElementLocator(Step.getLocatorFromWebElement(element));
 			dispatcher.beforeSendKeysByElement(stepBefore, element, param2);
 			currentStep = stepBefore;
+			takeScreenshot();
 
 			element.sendKeys(keysToSend);
 
+			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.sendKeysByElement);
 			stepAfter.setParam1(param1);
 			stepAfter.setParam2(param2);
@@ -898,9 +923,11 @@ public class EventFiringWebDriver
 			stepBefore.setElementLocator(Step.getLocatorFromWebElement(element));
 			dispatcher.beforeSubmit(stepBefore, element);
 			currentStep = stepBefore;
+			takeScreenshot();
 
 			element.submit();
 
+			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.submit);
 			stepAfter.setParam1(Step.getLocatorFromWebElement(element));
 			dispatcher.afterSubmit(stepAfter, element);
@@ -966,9 +993,11 @@ public class EventFiringWebDriver
 			Step stepBefore = new Step(Type.BeforeAction, stepNumber, Cmd.back);
 			dispatcher.beforeBack(stepBefore);
 			currentStep = stepBefore;
+			takeScreenshot();
 
 			navigation.back();
 
+			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.back);
 			dispatcher.afterBack(stepAfter);
 		}
@@ -978,9 +1007,11 @@ public class EventFiringWebDriver
 			Step stepBefore = new Step(Type.BeforeAction, stepNumber, Cmd.forward);
 			dispatcher.beforeForward(stepBefore);
 			currentStep = stepBefore;
+			takeScreenshot();
 
 			navigation.forward();
 
+			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.forward);
 			dispatcher.afterForward(stepAfter);
 		}
@@ -990,9 +1021,11 @@ public class EventFiringWebDriver
 			Step stepBefore = new Step(Type.BeforeAction, stepNumber, Cmd.refresh);
 			dispatcher.beforeRefresh(stepBefore);
 			currentStep = stepBefore;
+			takeScreenshot();
 
 			navigation.refresh();
 
+			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.refresh);
 			dispatcher.afterRefresh(stepAfter);
 		}
@@ -1379,9 +1412,11 @@ public class EventFiringWebDriver
 			stepBefore.setParam1(keysToSendString);
 			dispatcher.beforeSendKeysByKeyboard(stepBefore, keysToSend);
 			currentStep = stepBefore;
+			takeScreenshot();
 
 			keyboard.sendKeys(keysToSend);
 
+			takeScreenshot();
 			Step stepAfter = new Step(Type.AfterAction, stepNumber++, Cmd.sendKeysByKeyboard);
 			stepAfter.setParam1(keysToSendString);
 			dispatcher.afterSendKeysByKeyboard(stepBefore, keysToSend);


### PR DESCRIPTION
This enhancement will allow the user to decide whether they want to take a screenshot before performing actions such as **Click**, **executeScript**, **executeAsyncScript**, **Submit**, **Close**, **back**, **forward**, **refresh** and **SendKeys**. This capability is turned off by default and can be enabled by passing **takeScreenshotBeforeActions** value as **true** from command line.

Additionally, one can pass the location at which they want to save the screenshot. Following parameters can also be set from the command line:
**screenshotSaveLocation:** Absolute path of the location where screenshots should be saved. The default value of this parameter is set to save screenshots in the **screenshotHub** folder in the project's root directory.
**screenshotNamePrefix:** Pass the string that you wish to prefix to the screenshot file name. Default is set to empty string
**screenshotNamePostfix:** Pass the string that you wish to append to the screenshot file name. Default is set to empty string

If screenshotNamePrefix and/or screenshotNamePostfix is not passed screenshot file name will be the timestamp at which the screenshot was taken. The format of a screenshot file name is <Prefix><timestamp><postfix>.png.

**_NOTE:_** If **takeScreenshotBeforeActions** is not passed all other options described above are ignored.